### PR TITLE
Allow service middleware to store its own context details

### DIFF
--- a/header.go
+++ b/header.go
@@ -32,7 +32,7 @@ const (
 )
 
 func RequestBearerToken(r *http.Request) string {
-	if s := r.Header.Get(HeaderAuthorization); len(s) >= 7 && s[:7] == "bearer " {
+	if s := r.Header.Get(HeaderAuthorization); len(s) >= 7 && s[:7] == "Bearer " {
 		return s[7:]
 	}
 	return r.URL.Query().Get("access_token")

--- a/schema.go
+++ b/schema.go
@@ -23,17 +23,21 @@ func newSchemaHandler(filePath string) http.Handler {
 func (h *schemaHandler) ServeHTTP(rw http.ResponseWriter, req0 *http.Request) {
 	// Transform the request path to a path compatible with the schema directory
 	params := httptreemux.ContextParams(req0.Context())
-	versionStr := params["version"]
 
-	version, err := strconv.Atoi(versionStr)
+	versionStr := params["version"]
+	if len(versionStr) < 2 || versionStr[0] != 'v' {
+		rw.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	version, err := strconv.Atoi(versionStr[1:])
 	if err != nil || version < 1 {
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
 
 	filepath := params["filepath"]
-	file := fmt.Sprintf("/v%d/%s", version, filepath)
-	req1, err := http.NewRequest("GET", file, nil)
+	req1, err := http.NewRequest("GET", fmt.Sprintf("/v%d/%s", version, filepath), nil)
 	if err != nil {
 		panic(err)
 	}

--- a/service.go
+++ b/service.go
@@ -209,7 +209,7 @@ func (s *Service) addSchemaRoutes() {
 
 	// Serve the various schemas, e.g. /schema/v1, /schema/v2, etc.
 	h := newSchemaHandler(config.Schema.FilePath)
-	router.GET(path.Join(config.Schema.URIPath, "/v:version/", "*filepath"), h.ServeHTTP)
+	router.GET(path.Join(config.Schema.URIPath, ":version/*filepath"), h.ServeHTTP)
 
 	// Temporarily redirect (307) the base schema path to the default schema file, e.g. /schema -> /schema/v2/fileName
 	defaultSchemaPath := path.Join(config.Schema.URIPath, fmt.Sprintf("v%d", config.Version.Max), config.Schema.FileName)
@@ -218,7 +218,7 @@ func (s *Service) addSchemaRoutes() {
 	})
 
 	// Temporarily redirect (307) the version schema path to the default schema file, e.g. /schema/v2 -> /schema/v2/fileName
-	router.GET(path.Join(config.Schema.URIPath, "/v:version/"), func(rw http.ResponseWriter, req *http.Request) {
+	router.GET(path.Join(config.Schema.URIPath, ":version"), func(rw http.ResponseWriter, req *http.Request) {
 		http.Redirect(rw, req, defaultSchemaPath, http.StatusTemporaryRedirect)
 	})
 

--- a/test.go
+++ b/test.go
@@ -1,0 +1,30 @@
+package luddite
+
+import (
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// TestDispatch allows external code to test its own handlers, complete with
+// mocked luddite handler details.
+func TestDispatch(rw http.ResponseWriter, req *http.Request, h http.Handler) {
+	s := &Service{
+		config:        new(ServiceConfig),
+		defaultLogger: log.New(),
+	}
+
+	res := responseWriterPool.Get().(*responseWriter)
+	defer responseWriterPool.Put(res)
+	res.init(rw)
+
+	d := &handlerDetails{
+		s:          s,
+		rw:         res,
+		request:    req,
+		apiVersion: 1,
+	}
+
+	ctx := withHandlerDetails(req.Context(), d)
+	h.ServeHTTP(res, req.WithContext(ctx))
+}


### PR DESCRIPTION
* The v2 middleware dispatch avoids recursion and as a result, middleware is not
  allowed to "replace" the current request with its own. With the original
  luddite, this was done by some services' middleware because they needed to
  create a new request with amended context (because the `net/http` package
  doesn't let you replace a request's context).

* The new approach allows services' middleware to add their own details to the
  existing handler details without creating a new context or request. There is
  some cost to this, but it is less than the previous approach.

* Fixed a regression w/r/t schema route handling.

* Also added a test helper function that lets external code simulate request
  dispatch for unit testing purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/2)
<!-- Reviewable:end -->
