### PR TITLE
Defer optional HTTP handler creation until service is run

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -14,9 +14,9 @@ type schemaHandler struct {
 	fileServer http.Handler
 }
 
-func newSchemaHandler(filePath string) http.Handler {
+func newSchemaHandler(fs http.FileSystem) http.Handler {
 	return &schemaHandler{
-		fileServer: http.FileServer(http.Dir(filePath)),
+		fileServer: http.FileServer(fs),
 	}
 }
 


### PR DESCRIPTION
* Allows schema filesystem (and later potentially other things) to be configured
  or overridden by service code.

* Added SetSchemas method to the Service type to allow schema filesystem to be
  configured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/3)
<!-- Reviewable:end -->
