### PR TITLE
Don't insist on content negotation

### DIFF
--- a/body.go
+++ b/body.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	ContentTypeCss               = "text/css"
+	ContentTypeCsv               = "text/csv"
 	ContentTypeGif               = "image/gif"
 	ContentTypeHtml              = "text/html"
 	ContentTypeJson              = "application/json"
@@ -95,7 +96,7 @@ func WriteResponse(rw http.ResponseWriter, status int, v interface{}) (err error
 		case error:
 			v = NewError(nil, EcodeInternal, v)
 		}
-		switch rw.Header().Get(HeaderContentType) {
+		switch ct := rw.Header().Get(HeaderContentType); ct {
 		case ContentTypeJson:
 			b, err = json.Marshal(v)
 			if err != nil {
@@ -140,8 +141,14 @@ func WriteResponse(rw http.ResponseWriter, status int, v interface{}) (err error
 			switch v.(type) {
 			case []byte:
 				b = v.([]byte)
+				if ct == "" {
+					rw.Header().Set(HeaderContentType, ContentTypeOctetStream)
+				}
 			case string:
 				b = []byte(v.(string))
+				if ct == "" {
+					rw.Header().Set(HeaderContentType, ContentTypePlain)
+				}
 			default:
 				rw.WriteHeader(http.StatusNotAcceptable)
 				return

--- a/negotiator.go
+++ b/negotiator.go
@@ -24,13 +24,15 @@ func (n *negotiator) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Negotiate and set a Content-Type
-	format, err := negotiation.NegotiateAccept(accept, n.acceptedFormats)
-	if err != nil {
-		rw.WriteHeader(http.StatusNotAcceptable)
-		return
+	//
+	// Note: Negotation failures do not return 406 errors here. This allows
+	// resource handlers to potentially inspect/handle certain rarely-used
+	// content types on their own. If a negotiation failure has occurred and
+	// the resource handler doesn't deal with it, then we can expect a 406
+	// from WriteResponse.
+	if format, err := negotiation.NegotiateAccept(accept, n.acceptedFormats); err == nil {
+		rw.Header().Set(HeaderContentType, format.Value)
 	}
-
-	rw.Header().Set(HeaderContentType, format.Value)
 }
 
 // RegisterFormat registers a new format and associated MIME types.

--- a/negotiator_test.go
+++ b/negotiator_test.go
@@ -11,9 +11,44 @@ func TestDefaultContentType(t *testing.T) {
 	rw := httptest.NewRecorder()
 
 	n := newNegotiatorHandler([]string{ContentTypeJson, ContentTypeXml})
-
 	n.ServeHTTP(rw, req)
+
+	if res := rw.Result(); res != nil && res.StatusCode != http.StatusOK {
+		t.Error("result was written")
+	}
 	if rw.Header().Get(HeaderContentType) != ContentTypeJson {
 		t.Error("default content type not negotiated")
+	}
+}
+
+func TestSupportedContentType(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set(HeaderAccept, ContentTypeJson)
+	rw := httptest.NewRecorder()
+
+	n := newNegotiatorHandler([]string{ContentTypeJson, ContentTypeXml})
+	n.ServeHTTP(rw, req)
+
+	if res := rw.Result(); res != nil && res.StatusCode != http.StatusOK {
+		t.Error("result was written")
+	}
+	if ct := rw.Header().Get(HeaderContentType); ct != ContentTypeJson {
+		t.Errorf("incorrrect content type negotiated: %s", ct)
+	}
+}
+
+func TestUnsupportedContentType(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set(HeaderAccept, ContentTypeCsv)
+	rw := httptest.NewRecorder()
+
+	n := newNegotiatorHandler([]string{ContentTypeJson, ContentTypeXml})
+	n.ServeHTTP(rw, req)
+
+	if res := rw.Result(); res != nil && res.StatusCode != http.StatusOK {
+		t.Error("result was written")
+	}
+	if ct, ok := rw.Header()[HeaderContentType]; ok {
+		t.Errorf("incorrect content type negotiated: %s", ct)
 	}
 }


### PR DESCRIPTION
* Luddite has a design flaw where the list of accepted response formats is
  essentially fixed. This means that if/when resource handlers want to do
  something special like handling `Accept: text/csv`, then cannot do so.

* As described in the comment block, this change gives handlers a way to perform
  this special handling. If content negotation fails and the handler doesn't
  override, then the response will still contain a 406 via a fallback code path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/4)
<!-- Reviewable:end -->
