### PR TITLE
Fixed additional pprof profile routes

### DIFF
--- a/service.go
+++ b/service.go
@@ -198,6 +198,7 @@ func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
 	uriPath := s.config.Profiler.URIPath
 	router.GET(path.Join(uriPath, "/"), pprof.Index)
+	router.GET(path.Join(uriPath, "/*path"), pprof.Index)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)
 	router.GET(path.Join(uriPath, "/profile"), pprof.Profile)
 	router.POST(path.Join(uriPath, "/profile"), pprof.Profile)


### PR DESCRIPTION
Some pprof profile links weren't accessible from a web browser like:
```
http://localhost:8000/debug/pprof/heap?debug=1
http://localhost:8000/debug/pprof/block?debug=1
...
```
These are now accessible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/9)
<!-- Reviewable:end -->
