### PR TITLE
Addition of missing pprof routes.

### DIFF
--- a/service.go
+++ b/service.go
@@ -198,18 +198,18 @@ func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
 	uriPath := s.config.Profiler.URIPath
 	router.GET(path.Join(uriPath, "/"), pprof.Index)
+	router.GET(path.Join(uriPath, "/allocs"), pprof.Handler("allocs").ServeHTTP)
+	router.GET(path.Join(uriPath, "/block"), pprof.Handler("block").ServeHTTP)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)
+	router.GET(path.Join(uriPath, "/goroutine"), pprof.Handler("goroutine").ServeHTTP)
+	router.GET(path.Join(uriPath, "/heap"), pprof.Handler("heap").ServeHTTP)
+	router.GET(path.Join(uriPath, "/mutex"), pprof.Handler("mutex").ServeHTTP)
 	router.GET(path.Join(uriPath, "/profile"), pprof.Profile)
 	router.POST(path.Join(uriPath, "/profile"), pprof.Profile)
 	router.GET(path.Join(uriPath, "/symbol"), pprof.Symbol)
 	router.POST(path.Join(uriPath, "/symbol"), pprof.Symbol)
 	router.GET(path.Join(uriPath, "/trace"), pprof.Trace)
 	router.POST(path.Join(uriPath, "/trace"), pprof.Trace)
-	router.GET(path.Join(uriPath, "/allocs"), pprof.Handler("allocs").ServeHTTP)
-	router.GET(path.Join(uriPath, "/block"), pprof.Handler("block").ServeHTTP)
-	router.GET(path.Join(uriPath, "/goroutine"), pprof.Handler("goroutine").ServeHTTP)
-	router.GET(path.Join(uriPath, "/heap"), pprof.Handler("heap").ServeHTTP)
-	router.GET(path.Join(uriPath, "/mutex"), pprof.Handler("mutex").ServeHTTP)
 	router.GET(path.Join(uriPath, "/threadcreate"), pprof.Handler("threadcreate").ServeHTTP)
 }
 

--- a/service.go
+++ b/service.go
@@ -197,8 +197,7 @@ func (s *Service) addMetricsRoute() {
 func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
 	uriPath := s.config.Profiler.URIPath
-	router.GET(path.Join(uriPath, "/"), pprof.Index)
-	router.GET(path.Join(uriPath, "/*path"), pprof.Index)
+	router.GET(path.Join(uriPath, ""), pprof.Index)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)
 	router.GET(path.Join(uriPath, "/profile"), pprof.Profile)
 	router.POST(path.Join(uriPath, "/profile"), pprof.Profile)
@@ -206,6 +205,12 @@ func (s *Service) addProfilerRoutes() {
 	router.POST(path.Join(uriPath, "/symbol"), pprof.Symbol)
 	router.GET(path.Join(uriPath, "/trace"), pprof.Trace)
 	router.POST(path.Join(uriPath, "/trace"), pprof.Trace)
+	router.GET(path.Join(uriPath, "/allocs"), pprof.Handler("allocs").ServeHTTP)
+	router.GET(path.Join(uriPath, "/block"), pprof.Handler("block").ServeHTTP)
+	router.GET(path.Join(uriPath, "/goroutine"), pprof.Handler("goroutine").ServeHTTP)
+	router.GET(path.Join(uriPath, "/heap"), pprof.Handler("heap").ServeHTTP)
+	router.GET(path.Join(uriPath, "/mutex"), pprof.Handler("mutex").ServeHTTP)
+	router.GET(path.Join(uriPath, "/threadcreate"), pprof.Handler("threadcreate").ServeHTTP)
 }
 
 func (s *Service) addSchemaRoutes() {

--- a/service.go
+++ b/service.go
@@ -197,7 +197,7 @@ func (s *Service) addMetricsRoute() {
 func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
 	uriPath := s.config.Profiler.URIPath
-	router.GET(path.Join(uriPath, ""), pprof.Index)
+	router.GET(path.Join(uriPath, "/"), pprof.Index)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)
 	router.GET(path.Join(uriPath, "/profile"), pprof.Profile)
 	router.POST(path.Join(uriPath, "/profile"), pprof.Profile)

--- a/service.go
+++ b/service.go
@@ -208,9 +208,9 @@ func (s *Service) addProfilerRoutes() {
 	router.POST(path.Join(uriPath, "/profile"), pprof.Profile)
 	router.GET(path.Join(uriPath, "/symbol"), pprof.Symbol)
 	router.POST(path.Join(uriPath, "/symbol"), pprof.Symbol)
+	router.GET(path.Join(uriPath, "/threadcreate"), pprof.Handler("threadcreate").ServeHTTP)
 	router.GET(path.Join(uriPath, "/trace"), pprof.Trace)
 	router.POST(path.Join(uriPath, "/trace"), pprof.Trace)
-	router.GET(path.Join(uriPath, "/threadcreate"), pprof.Handler("threadcreate").ServeHTTP)
 }
 
 func (s *Service) addSchemaRoutes() {

--- a/service.go
+++ b/service.go
@@ -198,6 +198,7 @@ func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
 	uriPath := s.config.Profiler.URIPath
 	router.GET(path.Join(uriPath, "/"), pprof.Index)
+	router.GET(path.Join(uriPath, "/*path"), pprof.Index)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)
 	router.GET(path.Join(uriPath, "/profile"), pprof.Profile)
 	router.POST(path.Join(uriPath, "/profile"), pprof.Profile)


### PR DESCRIPTION
Some of the pprof profile links like:
```
http://localhost:8000/debug/pprof/heap?debug=1
http://localhost:8000/debug/pprof/block?debug=1
...
```
weren't accessible through a web browser. This is fixed in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/10)
<!-- Reviewable:end -->
