### PR TITLE
Fix pprof index page links.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 all: vet build test
 
 vet:
-	cd $(BUILD_PATH) && go vet -all -composites=false -shadow=true ./...
+	cd $(BUILD_PATH) && go vet -all -composites=false ./...
 
 build:
 	cd $(BUILD_PATH) && go build .

--- a/service.go
+++ b/service.go
@@ -197,7 +197,7 @@ func (s *Service) addMetricsRoute() {
 func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
 	uriPath := s.config.Profiler.URIPath
-	router.GET(path.Join(uriPath, "/"), pprof.Index)
+	router.GET(path.Clean(uriPath)+"/", pprof.Index)
 	router.GET(path.Join(uriPath, "/allocs"), pprof.Handler("allocs").ServeHTTP)
 	router.GET(path.Join(uriPath, "/block"), pprof.Handler("block").ServeHTTP)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)


### PR DESCRIPTION
path.Join() erases the trailing slashes (internally calls Clean), this produces broken links to the various profiles on the pprof index page.
Fixed it by concatenating a "/" to the cleaned base path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/11)
<!-- Reviewable:end -->
