### PR TITLE
Fixed broken links in pprof index page.

### DIFF
--- a/service.go
+++ b/service.go
@@ -196,8 +196,8 @@ func (s *Service) addMetricsRoute() {
 
 func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
-	uriPath := s.config.Profiler.URIPath
-	router.GET(path.Clean(uriPath)+"/", pprof.Index)
+	uriPath := path.Clean(s.config.Profiler.URIPath)
+	router.GET(strings.TrimRight(uriPath, "/")+"/", pprof.Index)
 	router.GET(path.Join(uriPath, "/allocs"), pprof.Handler("allocs").ServeHTTP)
 	router.GET(path.Join(uriPath, "/block"), pprof.Handler("block").ServeHTTP)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)

--- a/service.go
+++ b/service.go
@@ -197,7 +197,7 @@ func (s *Service) addMetricsRoute() {
 func (s *Service) addProfilerRoutes() {
 	router := s.globalRouter
 	uriPath := s.config.Profiler.URIPath
-	router.GET(path.Join(uriPath, "/"), pprof.Index)
+	router.GET(path.Clean(uriPath)+"/", pprof.Index)
 	router.GET(path.Join(uriPath, "/allocs"), pprof.Handler("allocs").ServeHTTP)
 	router.GET(path.Join(uriPath, "/block"), pprof.Handler("block").ServeHTTP)
 	router.GET(path.Join(uriPath, "/cmdline"), pprof.Cmdline)


### PR DESCRIPTION
`path.Join` trims the trailing slashes, this breaks the links in the pprof index page. Fixed it by concatenating a `"/"` to the base path instead of using the `path.Join` api.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/12)
<!-- Reviewable:end -->
