### PR TITLE
Improved test coverage of version.go.

### DIFF
--- a/version_test.go
+++ b/version_test.go
@@ -6,6 +6,18 @@ import (
 	"testing"
 )
 
+func TestNonPositiveVersionConstraint(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Add(HeaderSpirentApiVersion, "0")
+	rw := httptest.NewRecorder()
+	rw.Header().Set(HeaderContentType, ContentTypeJson)
+
+	v := newVersionHandler(2, 42)
+	v.ServeHTTP(rw, req)
+	if rw.Code != http.StatusBadRequest {
+		t.Error("expected 400/Bad request")
+	}
+}
 func TestMinApiVersionConstraint(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Add(HeaderSpirentApiVersion, "1")

--- a/version_test.go
+++ b/version_test.go
@@ -18,6 +18,7 @@ func TestNonPositiveVersionConstraint(t *testing.T) {
 		t.Error("expected 400/Bad request")
 	}
 }
+
 func TestMinApiVersionConstraint(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Add(HeaderSpirentApiVersion, "1")


### PR DESCRIPTION
Improved test coverage of `version.go` from 85% to 100% (`go tool cover`).
![Unit_test_before_after](https://user-images.githubusercontent.com/501545/60781286-69c51700-a15f-11e9-9fc3-2191bc700c91.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/13)
<!-- Reviewable:end -->
