### PR TITLE
base 'Location' header on req.URL.Path (in case the service is using 'prefix')

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -103,7 +103,7 @@ func AddCreateCollectionRoute(router *httptreemux.ContextMux, basePath string, r
 				url := url.URL{
 					Scheme: req.URL.Scheme,
 					Host:   req.URL.Host,
-					Path:   path.Join(basePath, r.Id(v1)),
+					Path:   path.Join(req.URL.Path, r.Id(v1)),
 				}
 				rw.Header().Add(HeaderLocation, url.String())
 			}


### PR DESCRIPTION
When the service is using a prefix for every basePath, the Location header was missing this prefix when a resource was created since it is not present in `basePath`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/15)
<!-- Reviewable:end -->
