### PR TITLE
Enable HTTP/2 support

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -74,7 +74,7 @@ func NewStoppableTCPListener(addr string, keepalives bool) (net.Listener, error)
 
 func NewStoppableTLSListener(addr string, keepalives bool, certFile string, keyFile string) (net.Listener, error) {
 	tlsConfig := &tls.Config{
-		NextProtos:   []string{"http/1.1"},
+		NextProtos:   []string{"http/1.1", "h2"},
 		Certificates: make([]tls.Certificate, 1),
 	}
 


### PR DESCRIPTION
As per Go http package documentation, the http.Serve() function will
support HTTP/2 as long as the Listener argument is configured with
"h2" in the TLS Config.NextProtos. This commit makes this change in the
StoppableListener implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/20)
<!-- Reviewable:end -->
