### PR TITLE
Page size validation

### DIFF
--- a/header.go
+++ b/header.go
@@ -56,7 +56,7 @@ func RequestNextLink(r *http.Request, cursor string) *url.URL {
 
 func RequestPageSize(r *http.Request) (pageSize int) {
 	var err error
-	if pageSize, err = strconv.Atoi(r.Header.Get(HeaderSpirentPageSize)); err != nil {
+	if pageSize, err = strconv.Atoi(r.Header.Get(HeaderSpirentPageSize)); err != nil || pageSize <= 0 {
 		pageSize = math.MaxInt32
 	}
 	return


### PR DESCRIPTION
Ignore specified size if <=0 and return math.MaxInt32. No other meaning can be ascribed to such values, and we are ignoring errors anyway. This saves every handler from validating page size value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite.v2/21)
<!-- Reviewable:end -->
